### PR TITLE
Don't need to exclude documentaiton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ src/*.o
 *.log*
 *.trace*
 haproxy-*
+!doc/haproxy-*.txt
 !src/*.c
 make-*
 dlmalloc.c


### PR DESCRIPTION
During some packaging I notice the private Git repo ignoring files. This addresses two doc files affected.
