### PR TITLE
Missing bracket

### DIFF
--- a/examples/haproxy.init
+++ b/examples/haproxy.init
@@ -94,7 +94,7 @@ check() {
   $BIN -c -q -V -f $CFG
 }
 
-quiet_check()
+quiet_check() {
   $BIN -c -q -f $CFG
 }
 


### PR DESCRIPTION
Curly brace is missing so the script won't execute
