### PR TITLE
add encoding to json converter example

### DIFF
--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -11784,7 +11784,7 @@ json([<input-code>])
   Example:
      capture request header user-agent len 150
      capture request header Host len 15
-     log-format {"ip":"%[src]","user-agent":"%[capture.req.hdr(1),json]"}
+     log-format {"ip":"%[src]","user-agent":"%[capture.req.hdr(1),json("utf8s")]"}
 
   Input request from client 127.0.0.1:
      GET / HTTP/1.0


### PR DESCRIPTION
Without the encoding `log-format` will issue a warning like:

```
$ haproxy -c -f /etc/haproxy/haproxy.cfg
[WARNING] 073/180933 (179) : parsing [/etc/haproxy/haproxy.cfg:46] : 'log-format' : sample fetch <capture.req.hdr(1),json> failed with : missing args for conv method 'json'
```
