### PR TITLE
Substitute header value

### DIFF
--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -3650,6 +3650,8 @@ http-request { allow | tarpit | auth [realm <realm>] | redirect <rule> |
               del-header <name> | set-nice <nice> | set-log-level <level> |
               replace-header <name> <match-regex> <replace-fmt> |
               replace-value <name> <match-regex> <replace-fmt> |
+              substitute-header <name> <match-regex> <replace-fmt> <options> |
+              substitute-value <name> <match-regex> <replace-fmt> <options> |
               set-method <fmt> | set-path <fmt> | set-query <fmt> |
               set-uri <fmt> | set-tos <tos> | set-mark <mark> |
               add-acl(<file name>) <key fmt> |
@@ -3768,6 +3770,29 @@ http-request { allow | tarpit | auth [realm <realm>] | redirect <rule> |
       outputs:
 
         X-Forwarded-For: 172.16.10.1, 172.16.13.24, 10.0.0.37
+
+    - "substitute-header" works similar to "replace-header" but it only
+      substitutes the matching parts within the original header. This makes
+      it possible to replace a varying number of matching parts within the
+      original header. <options> argument can only have value "g" meaning
+      substitute all matches. If <options> is empty "", only the first match
+      gets substituted.
+
+      Example:
+
+        http-request susbtitute-header Referer '-(?=.*\.example\.com)' '.' 'g'
+
+      applied to:
+
+        Referer: https://a-b-c.example.com/x-caliber
+
+      outputs:
+
+        Referer: https://a.b.c.example.com/x-caliber
+
+    - "substitute-value" works similar to "substitute-header" except that it 
+      matches the regex against every comma-delimited value of the header field
+      <name> instead of the entire header (as done in "replace-value"). 
 
     - "set-method" rewrites the request method with the result of the
       evaluation of format string <fmt>. There should be very few valid reasons
@@ -4122,6 +4147,8 @@ http-response { allow | deny | add-header <name> <fmt> | set-nice <nice> |
                 set-header <name> <fmt> | del-header <name> |
                 replace-header <name> <regex-match> <replace-fmt> |
                 replace-value <name> <regex-match> <replace-fmt> |
+                substitute-header <name> <regex-match> <replace-fmt> <options> |
+                substitute-value <name> <regex-match> <replace-fmt> <options> |
                 set-status <status> |
                 set-log-level <level> | set-mark <mark> | set-tos <tos> |
                 add-acl(<file name>) <key fmt> |
@@ -4213,6 +4240,30 @@ http-response { allow | deny | add-header <name> <fmt> | set-nice <nice> |
       outputs:
 
         Cache-Control: max-age=3600, private
+
+    - "substitute-header" works similar to "replace-header" but it only
+      substitutes the matching parts within the original header. This makes
+      it possible to replace a varying number of matching parts within the 
+      original header. <options> argument can only have value "g" meaning
+      substitute all matches. If <options> is empty "", only the first match
+      gets substituted.
+
+      Example:
+
+        http-request susbtitute-header Access-Control-Allow-Origin \
+          '-(?=.*\.example\.com)' '.' 'g'
+
+      applied to:
+
+        Access-Control-Allow-Origin: https://a-b-c.example.com/x-caliber
+
+      outputs:
+
+        Access-Control-Allow-Origin: https://a.b.c.example.com/x-caliber
+
+    - "substitute-value" works similar to "substitute-header" except that it
+      matches the regex against every comma-delimited value of the header field
+      <name> instead of the entire header (as done in "replace-value").
 
     - "set-status" replaces the response status code with <status> which must
       be an integer between 100 and 999. Note that the reason is automatically

--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -4250,7 +4250,7 @@ http-response { allow | deny | add-header <name> <fmt> | set-nice <nice> |
 
       Example:
 
-        http-request susbtitute-header Access-Control-Allow-Origin \
+        http-response susbtitute-header Access-Control-Allow-Origin \
           '-(?=.*\.example\.com)' '.' 'g'
 
       applied to:

--- a/doc/lua-api/index.rst
+++ b/doc/lua-api/index.rst
@@ -1318,6 +1318,38 @@ HTTP class
   :param string replace: The replacement value.
   :see: HTTP.req_replace_header()
 
+.. js:function:: HTTP.req_sub_header(http, name, regex, replace, options)
+
+  Matches the regular expression in all occurrences of header field "name"
+  according to "regex", and substitutes matches with the "replace" argument.
+  The replacement value can contain back references like \1, \2, ... If the
+  "options" argument contains "g" all matches are substituted - if empty 
+  only only the first match in each header is substituted. This
+  function works with the request.
+
+  :param class_http http: The related http object.
+  :param string name: The header name.
+  :param string regex: The match regular expression.
+  :param string replace: The replacement value.
+  :param string options: Regex substitution options.
+  :see: HTTP.res_sub_header()
+
+.. js:function:: HTTP.res_sub_header(http, name, regex, string, options)
+
+  Matches the regular expression in all occurrences of header field "name"
+  according to "regex", and substitutes matches with the "replace" argument.
+  The replacement value can contain back references like \1, \2, ... If the
+  "options" argument contains "g" all matches are substituted - if empty 
+  only only the first match in each header is substituted. This
+  function works with the response.
+
+  :param class_http http: The related http object.
+  :param string name: The header name.
+  :param string regex: The match regular expression.
+  :param string replace: The replacement value.
+  :param string options: Regex substitution options.
+  :see: HTTP.req_sub_header()
+
 .. js:function:: HTTP.req_set_method(http, method)
 
   Rewrites the request method with the parameter "method".

--- a/include/common/regex.h
+++ b/include/common/regex.h
@@ -156,7 +156,7 @@ static inline void regex_free(struct my_regex *preg) {
  * "err" is the standard error message pointer.
  *
  * The function returns the bit mask of regex substitution options.
- * Its value is > 0 in case of success or negative in case of failue.
+ * Its value is >= 0 in case of success or negative in case of failure.
  */
 regex_subst_opts_t regex_subst_options_comp(const char *options_str, char **err);
 

--- a/include/common/regex.h
+++ b/include/common/regex.h
@@ -62,6 +62,10 @@ struct my_regex {
 #define ACT_PASS	4	/* pass this header without allowing or denying the request */
 #define ACT_TARPIT	5	/* tarpit the connection matching this request */
 
+/* define regex substitution options */
+typedef char regex_subst_opts;
+#define RE_SUBST_GLOBAL 1       /* Global substitution */
+
 struct hdr_exp {
     struct hdr_exp *next;
     struct my_regex *preg;		/* expression to look for */

--- a/include/common/regex.h
+++ b/include/common/regex.h
@@ -63,7 +63,7 @@ struct my_regex {
 #define ACT_TARPIT	5	/* tarpit the connection matching this request */
 
 /* define regex substitution options */
-typedef char regex_subst_opts;
+typedef char regex_subst_opts_t;
 #define RE_SUBST_GLOBAL 1       /* Global substitution */
 
 struct hdr_exp {
@@ -151,6 +151,14 @@ static inline void regex_free(struct my_regex *preg) {
 	regfree(&preg->regex);
 #endif
 }
+
+/* "options_str" is the string of regex substitution options
+ * "err" is the standard error message pointer.
+ *
+ * The function returns the bit mask of regex substitution options.
+ * Its value is > 0 in case of success or negative in case of failue.
+ */
+regex_subst_opts_t regex_subst_options_comp(const char *options_str, char **err);
 
 #endif /* _COMMON_REGEX_H */
 

--- a/include/proto/proto_http.h
+++ b/include/proto/proto_http.h
@@ -114,7 +114,7 @@ int http_replace_header_str(struct stream* s, struct http_msg *msg, const char* 
                               int action);
 int http_substitute_header_str(struct stream* s, struct http_msg *msg, const char* name,
                               unsigned int name_len, const char *str, struct my_regex *re,
-                              int action, regex_subst_opts re_options);
+                              int action, regex_subst_opts_t re_options);
 void inet_set_tos(int fd, const struct sockaddr_storage *from, int tos);
 void http_perform_server_redirect(struct stream *s, struct stream_interface *si);
 void http_return_srv_error(struct stream *s, struct stream_interface *si);

--- a/include/proto/proto_http.h
+++ b/include/proto/proto_http.h
@@ -109,9 +109,12 @@ int http_remove_header2(struct http_msg *msg, struct hdr_idx *idx, struct hdr_ct
 int http_header_add_tail2(struct http_msg *msg, struct hdr_idx *hdr_idx, const char *text, int len);
 int http_replace_req_line(int action, const char *replace, int len, struct proxy *px, struct stream *s);
 void http_set_status(unsigned int status, struct stream *s);
-int http_transform_header_str(struct stream* s, struct http_msg *msg, const char* name,
+int http_replace_header_str(struct stream* s, struct http_msg *msg, const char* name,
                               unsigned int name_len, const char *str, struct my_regex *re,
                               int action);
+int http_substitute_header_str(struct stream* s, struct http_msg *msg, const char* name,
+                              unsigned int name_len, const char *str, struct my_regex *re,
+                              int action, regex_subst_opts re_options);
 void inet_set_tos(int fd, const struct sockaddr_storage *from, int tos);
 void http_perform_server_redirect(struct stream *s, struct stream_interface *si);
 void http_return_srv_error(struct stream *s, struct stream_interface *si);

--- a/include/types/action.h
+++ b/include/types/action.h
@@ -66,6 +66,8 @@ enum act_name {
 	ACT_HTTP_ADD_HDR,
 	ACT_HTTP_REPLACE_HDR,
 	ACT_HTTP_REPLACE_VAL,
+	ACT_HTTP_SUBSTITUTE_HDR,
+	ACT_HTTP_SUBSTITUTE_VAL,
 	ACT_HTTP_SET_HDR,
 	ACT_HTTP_DEL_HDR,
 	ACT_HTTP_REDIR,
@@ -112,7 +114,8 @@ struct act_rule {
 			char *name;            /* header name */
 			int name_len;          /* header name's length */
 			struct list fmt;       /* log-format compatible expression */
-			struct my_regex re;    /* used by replace-header and replace-value */
+			struct my_regex re;    /* used by replace/substitute-header and replace/substitute-value */
+			regex_subst_opts re_options; /* substitute-header/value regex flags */
 		} hdr_add;                     /* args used by "add-header" and "set-header" */
 		struct redirect_rule *redir;   /* redirect rule or "http-request redirect" */
 		int nice;                      /* nice value for ACT_HTTP_SET_NICE */

--- a/include/types/action.h
+++ b/include/types/action.h
@@ -115,7 +115,7 @@ struct act_rule {
 			int name_len;          /* header name's length */
 			struct list fmt;       /* log-format compatible expression */
 			struct my_regex re;    /* used by replace/substitute-header and replace/substitute-value */
-			regex_subst_opts re_options; /* substitute-header/value regex flags */
+			regex_subst_opts_t re_options; /* substitute-header/value regex flags */
 		} hdr_add;                     /* args used by "add-header" and "set-header" */
 		struct redirect_rule *redir;   /* redirect rule or "http-request redirect" */
 		int nice;                      /* nice value for ACT_HTTP_SET_NICE */

--- a/src/hlua.c
+++ b/src/hlua.c
@@ -4352,7 +4352,7 @@ __LJMP static inline int hlua_http_sub_hdr(lua_State *L, struct hlua_txn *htxn,
 	const char *value = MAY_LJMP(luaL_checkstring(L, 4));
 	const char *options = MAY_LJMP(luaL_checkstring(L, 5));
 	struct my_regex re;
-	regex_subst_opts re_options = 0;
+	regex_subst_opts_t re_options = 0;
 
 	/* Check if a valid response is parsed */
 	if (unlikely(msg->msg_state < HTTP_MSG_BODY))

--- a/src/hlua.c
+++ b/src/hlua.c
@@ -4361,12 +4361,9 @@ __LJMP static inline int hlua_http_sub_hdr(lua_State *L, struct hlua_txn *htxn,
 	if (!regex_comp(reg, &re, 1, 1, NULL))
 		WILL_LJMP(luaL_argerror(L, 3, "invalid regex"));
 
-        // FIXME add proper regex sub compile function
-	if (strcmp(options,"g") == 0)
-		re_options |= 1;
-        else if (*options == '\0')
-		re_options = 0;
-	else
+
+	re_options = regex_subst_options_comp(options, NULL);
+	if (re_options < 0) 
 		WILL_LJMP(luaL_argerror(L, 4, "invalid regex options"));	
 
 	http_substitute_header_str(htxn->s, msg, name, name_len, value, &re, action, re_options);

--- a/src/proto_http.c
+++ b/src/proto_http.c
@@ -3379,23 +3379,23 @@ int http_substitute_header_str(struct stream* s, struct http_msg *msg,
                 start_match_offset = pmatch[0].rm_so;
 
                 do {
-                  /* if this is not first match and match does not start from beginning and enough space then copy directly */
-                  if (end_match_offset && pmatch[0].rm_so && ((output->size - output->len) >= pmatch[0].rm_so ))
-                    if (memcpy(output->str + output->len, val+end_match_offset, pmatch[0].rm_so))
-                      output->len += pmatch[0].rm_so;
+                	/* if this is not first match and match does not start from beginning and enough space then copy directly */
+                	if (end_match_offset && pmatch[0].rm_so && ((output->size - output->len) >= pmatch[0].rm_so ))
+                		if (memcpy(output->str + output->len, val+end_match_offset, pmatch[0].rm_so))
+                			output->len += pmatch[0].rm_so;
 
-                  res = exp_replace(output->str + output->len, output->size - output->len, val + end_match_offset, str, pmatch);
+                	res = exp_replace(output->str + output->len, output->size - output->len, val + end_match_offset, str, pmatch);
 
-                  if (res == -1)
-                    return -1;
-                  output->len += res;
+                	if (res == -1)
+                		return -1;
+                	output->len += res;
 
-                  end_match_offset += pmatch[0].rm_eo;
+                	end_match_offset += pmatch[0].rm_eo;
 
-                  /* checking if more matches are possibe: 
-                     Regex global matches flag is on and more bytes to read after last match */
-                  if ((re_options&RE_SUBST_GLOBAL) && (end_match_offset >= (val_end-val)))
-                    break;
+                	/* continue only if more matches are possibe: 
+                	   Regex global matches flag is on and more bytes to read after last match */
+                	if ((!re_options&RE_SUBST_GLOBAL) || (end_match_offset >= (val_end-val)))
+                		break;
                 }
                 while (regex_exec_match2(re, val + end_match_offset, (val_end-val) - end_match_offset , MAX_MATCH, pmatch, 0)  );
 

--- a/src/proto_http.c
+++ b/src/proto_http.c
@@ -3340,7 +3340,7 @@ void inet_set_tos(int fd, const struct sockaddr_storage *from, int tos)
 int http_substitute_header_str(struct stream* s, struct http_msg *msg,
                               const char* name, unsigned int name_len,
                               const char *str, struct my_regex *re,
-                              int action, regex_subst_opts re_options)
+                              int action, regex_subst_opts_t re_options)
 {
 	struct hdr_ctx ctx;
 	char *buf = msg->chn->buf->p;
@@ -3466,7 +3466,7 @@ int http_replace_header_str(struct stream* s, struct http_msg *msg,
 static int http_transform_header(struct stream* s, struct http_msg *msg,
                                  const char* name, unsigned int name_len,
                                  struct list *fmt, struct my_regex *re,
-                                 int action, regex_subst_opts re_options)
+                                 int action, regex_subst_opts_t re_options)
 {
 	struct chunk *replace = get_trash_chunk();
 

--- a/src/proto_http.c
+++ b/src/proto_http.c
@@ -3337,7 +3337,82 @@ void inet_set_tos(int fd, const struct sockaddr_storage *from, int tos)
 #endif
 }
 
-int http_transform_header_str(struct stream* s, struct http_msg *msg,
+int http_substitute_header_str(struct stream* s, struct http_msg *msg,
+                              const char* name, unsigned int name_len,
+                              const char *str, struct my_regex *re,
+                              int action, regex_subst_opts re_options)
+{
+	struct hdr_ctx ctx;
+	char *buf = msg->chn->buf->p;
+	struct hdr_idx *idx = &s->txn->hdr_idx;
+	int (*http_find_hdr_func)(const char *name, int len, char *sol,
+	                          struct hdr_idx *idx, struct hdr_ctx *ctx);
+	struct chunk *output = get_trash_chunk();
+
+	ctx.idx = 0;
+
+	/* Choose the header browsing function. */
+	switch (action) {
+	case ACT_HTTP_SUBSTITUTE_VAL:
+		http_find_hdr_func = http_find_header2;
+		break;
+	case ACT_HTTP_SUBSTITUTE_HDR:
+		http_find_hdr_func = http_find_full_header2;
+		break;
+	default: /* impossible */
+		return -1;
+	}
+
+	while (http_find_hdr_func(name, name_len, buf, idx, &ctx)) {
+		struct hdr_idx_elem *hdr = idx->v + ctx.idx;
+		int delta;
+		char *val = ctx.line + ctx.val;
+		char* val_end = val + ctx.vlen;
+                int end_match_offset = 0; // holds offset of end of all matches from start of string
+                int start_match_offset = 0; // holds offset of start of all matches from start of string
+                int res;
+                output->len = 0;
+
+                if (!regex_exec_match2(re, val, val_end-val, MAX_MATCH, pmatch, 0))
+                        continue;
+
+                start_match_offset = pmatch[0].rm_so;
+
+                do {
+                  /* if this is not first match and match does not start from beginning and enough space then copy directly */
+                  if (end_match_offset && pmatch[0].rm_so && ((output->size - output->len) >= pmatch[0].rm_so ))
+                    if (memcpy(output->str + output->len, val+end_match_offset, pmatch[0].rm_so))
+                      output->len += pmatch[0].rm_so;
+
+                  res = exp_replace(output->str + output->len, output->size - output->len, val + end_match_offset, str, pmatch);
+
+                  if (res == -1)
+                    return -1;
+                  output->len += res;
+
+                  end_match_offset += pmatch[0].rm_eo;
+
+                  /* checking if more matches are possibe: 
+                     Regex global matches flag is on and more bytes to read after last match */
+                  if ((re_options&RE_SUBST_GLOBAL) && (end_match_offset >= (val_end-val)))
+                    break;
+                }
+                while (regex_exec_match2(re, val + end_match_offset, (val_end-val) - end_match_offset , MAX_MATCH, pmatch, 0)  );
+
+                delta = buffer_replace2(msg->chn->buf, val+start_match_offset, val + end_match_offset, output->str, output->len);
+
+
+		hdr->len += delta;
+		http_msg_move_end(msg, delta);
+
+		/* Adjust the length of the current value of the index. */
+		ctx.vlen += delta;
+	}
+
+	return 0;
+}
+
+int http_replace_header_str(struct stream* s, struct http_msg *msg,
                               const char* name, unsigned int name_len,
                               const char *str, struct my_regex *re,
                               int action)
@@ -3391,7 +3466,7 @@ int http_transform_header_str(struct stream* s, struct http_msg *msg,
 static int http_transform_header(struct stream* s, struct http_msg *msg,
                                  const char* name, unsigned int name_len,
                                  struct list *fmt, struct my_regex *re,
-                                 int action)
+                                 int action, regex_subst_opts re_options)
 {
 	struct chunk *replace = get_trash_chunk();
 
@@ -3399,7 +3474,11 @@ static int http_transform_header(struct stream* s, struct http_msg *msg,
 	if (replace->len >= replace->size - 1)
 		return -1;
 
-	return http_transform_header_str(s, msg, name, name_len, replace->str, re, action);
+        if (action ==  ACT_HTTP_REPLACE_HDR || action ==  ACT_HTTP_REPLACE_VAL)
+		return http_replace_header_str(s, msg, name, name_len, replace->str, re, action);
+        else
+		/* action ==  ACT_HTTP_SUBSTITUTE_HDR || action ==  ACT_HTTP_SUBSTITUTE_VAL */
+		return http_substitute_header_str(s, msg, name, name_len, replace->str, re, action, re_options);
 }
 
 /* Executes the http-request rules <rules> for stream <s>, proxy <px> and
@@ -3515,6 +3594,8 @@ resume_execution:
 
 		case ACT_HTTP_REPLACE_HDR:
 		case ACT_HTTP_REPLACE_VAL:
+		case ACT_HTTP_SUBSTITUTE_HDR:
+		case ACT_HTTP_SUBSTITUTE_VAL:
 			if (http_transform_header(s, &txn->req, rule->arg.hdr_add.name,
 			                          rule->arg.hdr_add.name_len,
 			                          &rule->arg.hdr_add.fmt,
@@ -3784,6 +3865,8 @@ resume_execution:
 
 		case ACT_HTTP_REPLACE_HDR:
 		case ACT_HTTP_REPLACE_VAL:
+		case ACT_HTTP_SUBSTITUTE_HDR:
+		case ACT_HTTP_SUBSTITUTE_VAL:
 			if (http_transform_header(s, &txn->rsp, rule->arg.hdr_add.name,
 			                          rule->arg.hdr_add.name_len,
 			                          &rule->arg.hdr_add.fmt,
@@ -9195,6 +9278,52 @@ struct act_rule *parse_http_req_cond(const char **args, const char *file, int li
 		proxy->conf.lfs_file = strdup(proxy->conf.args.file);
 		proxy->conf.lfs_line = proxy->conf.args.line;
 		cur_arg += 3;
+	} else if (strcmp(args[0], "substitute-header") == 0 || strcmp(args[0], "substitute-value") == 0 ) {
+		rule->action = args[0][11] == 'h' ? ACT_HTTP_SUBSTITUTE_HDR : ACT_HTTP_SUBSTITUTE_VAL;
+		cur_arg = 1;
+
+		if (!*args[cur_arg] || !*args[cur_arg+1] || !*args[cur_arg+2] || !*args[cur_arg+3]
+			(*args[cur_arg+4] && strcmp(args[cur_arg+4], "if") != 0 && strcmp(args[cur_arg+4], "unless") != 0)) {
+			Alert("parsing [%s:%d]: 'http-request %s' expects exactly 4 arguments.\n",
+			      file, linenum, args[0]);
+			goto out_err;
+		}
+
+		rule->arg.hdr_add.name = strdup(args[cur_arg]);
+		rule->arg.hdr_add.name_len = strlen(rule->arg.hdr_add.name);
+		LIST_INIT(&rule->arg.hdr_add.fmt);
+
+		error = NULL;
+		if (!regex_comp(args[cur_arg + 1], &rule->arg.hdr_add.re, 1, 1, &error)) {
+			Alert("parsing [%s:%d] : '%s' : %s.\n", file, linenum,
+			      args[cur_arg + 1], error);
+			free(error);
+			goto out_err;
+		}
+
+		proxy->conf.args.ctx = ARGC_HRQ;
+		error = NULL;
+		if (!parse_logformat_string(args[cur_arg + 2], proxy, &rule->arg.hdr_add.fmt, LOG_OPT_HTTP,
+		                            (proxy->cap & PR_CAP_FE) ? SMP_VAL_FE_HRQ_HDR : SMP_VAL_BE_HRQ_HDR, &error)) {
+			Alert("parsing [%s:%d]: 'http-request %s': %s.\n",
+			      file, linenum, args[0], error);
+			free(error);
+			goto out_err;
+		}
+
+		rule->arg.hdr_add.re_options = 0;
+		if (strcmp(args[cur_arg+3], "g")) {
+			rule->arg.hdr_add.re_options |= RE_SUBST_GLOBAL;
+		} else if (*args[cur_arg+3][0] != '\0') {
+			Alert("parsing [%s:%d]: 'http-request %s': Invalid regex substitution option.\n", file, linenum,
+			args[0]);
+			goto out_err;
+		}
+
+		free(proxy->conf.lfs_file);
+		proxy->conf.lfs_file = strdup(proxy->conf.args.file);
+		proxy->conf.lfs_line = proxy->conf.args.line;
+		cur_arg += 4;
 	} else if (strcmp(args[0], "del-header") == 0) {
 		rule->action = ACT_HTTP_DEL_HDR;
 		cur_arg = 1;
@@ -9635,6 +9764,52 @@ struct act_rule *parse_http_res_cond(const char **args, const char *file, int li
 		proxy->conf.lfs_file = strdup(proxy->conf.args.file);
 		proxy->conf.lfs_line = proxy->conf.args.line;
 		cur_arg += 3;
+	} else if (strcmp(args[0], "substitute-header") == 0 || strcmp(args[0], "substitute-value") == 0) {
+		rule->action = args[0][11] == 'h' ? ACT_HTTP_SUBSTITUTE_HDR : ACT_HTTP_SUBSTITUTE_VAL;
+		cur_arg = 1;
+
+		if (!*args[cur_arg] || !*args[cur_arg+1] || !*args[cur_arg+2] || !*args[cur_arg+3]
+		    (*args[cur_arg+4] && strcmp(args[cur_arg+4], "if") != 0 && strcmp(args[cur_arg+4], "unless") != 0)) {
+			Alert("parsing [%s:%d]: 'http-response %s' expects exactly 4 arguments.\n",
+			      file, linenum, args[0]);
+			goto out_err;
+		}
+
+		rule->arg.hdr_add.name = strdup(args[cur_arg]);
+		rule->arg.hdr_add.name_len = strlen(rule->arg.hdr_add.name);
+		LIST_INIT(&rule->arg.hdr_add.fmt);
+
+		error = NULL;
+		if (!regex_comp(args[cur_arg + 1], &rule->arg.hdr_add.re, 1, 1, &error)) {
+			Alert("parsing [%s:%d] : '%s' : %s.\n", file, linenum,
+			      args[cur_arg + 1], error);
+			free(error);
+			goto out_err;
+		}
+
+		proxy->conf.args.ctx = ARGC_HRQ;
+		error = NULL;
+		if (!parse_logformat_string(args[cur_arg + 2], proxy, &rule->arg.hdr_add.fmt, LOG_OPT_HTTP,
+		                            (proxy->cap & PR_CAP_BE) ? SMP_VAL_BE_HRS_HDR : SMP_VAL_FE_HRS_HDR, &error)) {
+			Alert("parsing [%s:%d]: 'http-response %s': %s.\n",
+			      file, linenum, args[0], error);
+			free(error);
+			goto out_err;
+		}
+
+		rule->arg.hdr_add.re_options = 0;
+		if (strcmp(args[cur_arg+3], "g")) {
+			rule->arg.hdr_add.re_options |= RE_SUBST_GLOBAL;
+		} else if (*args[cur_arg+3][0] != '\0') {
+			Alert("parsing [%s:%d]: 'http-response %s': Invalid regex substitution option.\n", file, linenum,
+			args[0]);
+			goto out_err;
+		}
+
+		free(proxy->conf.lfs_file);
+		proxy->conf.lfs_file = strdup(proxy->conf.args.file);
+		proxy->conf.lfs_line = proxy->conf.args.line;
+		cur_arg += 4;
 	} else if (strcmp(args[0], "del-header") == 0) {
 		rule->action = ACT_HTTP_DEL_HDR;
 		cur_arg = 1;
@@ -9880,7 +10055,8 @@ struct act_rule *parse_http_res_cond(const char **args, const char *file, int li
 	} else {
 		action_build_list(&http_res_keywords.list, &trash);
 		Alert("parsing [%s:%d]: 'http-response' expects 'allow', 'deny', 'redirect', "
-		      "'add-header', 'del-header', 'set-header', 'replace-header', 'replace-value', 'set-nice', "
+		      "'add-header', 'del-header', 'set-header', 'replace-header', 'replace-value', "
+                      "'substitute-header', 'substitute-value', 'set-nice', "
 		      "'set-tos', 'set-mark', 'set-log-level', 'add-acl', 'del-acl', 'del-map', 'set-map', 'track-sc*'"
 		      "%s%s, but got '%s'%s.\n",
 		      file, linenum, *trash.str ? ", " : "", trash.str, args[0], *args[0] ? "" : " (missing argument)");

--- a/src/proto_http.c
+++ b/src/proto_http.c
@@ -9316,12 +9316,11 @@ struct act_rule *parse_http_req_cond(const char **args, const char *file, int li
 			goto out_err;
 		}
 
-		rule->arg.hdr_add.re_options = 0;
-		if (strcmp(args[cur_arg+3], "g") == 0) {
-			rule->arg.hdr_add.re_options |= RE_SUBST_GLOBAL;
-		} else if (args[cur_arg+3][0] != '\0') {
-			Alert("parsing [%s:%d]: 'http-request %s': Invalid regex substitution option.\n", file, linenum,
-			args[0]);
+		rule->arg.hdr_add.re_options = regex_subst_options_comp(args[cur_arg+3], &error);
+		if (rule->arg.hdr_add.re_options < 0) {
+			Alert("parsing [%s:%d]: 'http-request %s': %s.\n", file, linenum,
+			args[0], error);
+			free(error);
 			goto out_err;
 		}
 
@@ -9805,12 +9804,11 @@ struct act_rule *parse_http_res_cond(const char **args, const char *file, int li
 			goto out_err;
 		}
 
-		rule->arg.hdr_add.re_options = 0;
-		if (strcmp(args[cur_arg+3], "g") == 0) {
-			rule->arg.hdr_add.re_options |= RE_SUBST_GLOBAL;
-		} else if (args[cur_arg+3][0] != '\0') {
-			Alert("parsing [%s:%d]: 'http-response %s': Invalid regex substitution option.\n", file, linenum,
-			args[0]);
+		rule->arg.hdr_add.re_options = regex_subst_options_comp(args[cur_arg+3], &error);
+		if (rule->arg.hdr_add.re_options < 0) {
+			Alert("parsing [%s:%d]: 'http-response %s': %s.\n", file, linenum,
+			args[0], error);
+			free(error);
 			goto out_err;
 		}
 

--- a/src/proto_http.c
+++ b/src/proto_http.c
@@ -3368,38 +3368,38 @@ int http_substitute_header_str(struct stream* s, struct http_msg *msg,
 		int delta;
 		char *val = ctx.line + ctx.val;
 		char* val_end = val + ctx.vlen;
-                int end_match_offset = 0; // holds offset of end of all matches from start of string
-                int start_match_offset = 0; // holds offset of start of all matches from start of string
-                int res;
-                output->len = 0;
+		int end_match_offset = 0; // holds offset of end of all matches from start of string
+		int start_match_offset = 0; // holds offset of start of all matches from start of string
+		int res;
+		output->len = 0;
 
-                if (!regex_exec_match2(re, val, val_end-val, MAX_MATCH, pmatch, 0))
-                        continue;
+		if (!regex_exec_match2(re, val, val_end-val, MAX_MATCH, pmatch, 0))
+		        continue;
 
-                start_match_offset = pmatch[0].rm_so;
+		start_match_offset = pmatch[0].rm_so;
 
-                do {
-                	/* if this is not first match and match does not start from beginning and enough space then copy directly */
-                	if (end_match_offset && pmatch[0].rm_so && ((output->size - output->len) >= pmatch[0].rm_so ))
-                		if (memcpy(output->str + output->len, val+end_match_offset, pmatch[0].rm_so))
-                			output->len += pmatch[0].rm_so;
+		do {
+			/* if this is not first match and match does not start from beginning and enough space then copy directly */
+			if (end_match_offset && pmatch[0].rm_so && ((output->size - output->len) >= pmatch[0].rm_so ))
+				if (memcpy(output->str + output->len, val+end_match_offset, pmatch[0].rm_so))
+					output->len += pmatch[0].rm_so;
 
-                	res = exp_replace(output->str + output->len, output->size - output->len, val + end_match_offset, str, pmatch);
+			res = exp_replace(output->str + output->len, output->size - output->len, val + end_match_offset, str, pmatch);
 
-                	if (res == -1)
-                		return -1;
-                	output->len += res;
+			if (res == -1)
+				return -1;
+			output->len += res;
 
-                	end_match_offset += pmatch[0].rm_eo;
+			end_match_offset += pmatch[0].rm_eo;
 
-                	/* continue only if more matches are possibe: 
-                	   Regex global matches flag is on and more bytes to read after last match */
-                	if ((!re_options&RE_SUBST_GLOBAL) || (end_match_offset >= (val_end-val)))
-                		break;
-                }
-                while (regex_exec_match2(re, val + end_match_offset, (val_end-val) - end_match_offset , MAX_MATCH, pmatch, 0)  );
+			/* continue only if more matches are possibe: 
+			   Regex global matches flag is on and more bytes to read after last match */
+			if ((!re_options&RE_SUBST_GLOBAL) || (end_match_offset >= (val_end-val)))
+				break;
+		}
+		while (regex_exec_match2(re, val + end_match_offset, (val_end-val) - end_match_offset , MAX_MATCH, pmatch, 0)  );
 
-                delta = buffer_replace2(msg->chn->buf, val+start_match_offset, val + end_match_offset, output->str, output->len);
+		delta = buffer_replace2(msg->chn->buf, val+start_match_offset, val + end_match_offset, output->str, output->len);
 
 
 		hdr->len += delta;

--- a/src/regex.c
+++ b/src/regex.c
@@ -326,6 +326,18 @@ int regex_comp(const char *str, struct my_regex *regex, int cs, int cap, char **
 	return 1;
 }
 
+regex_subst_opts_t regex_subst_options_comp(const char *options_str, char **err){
+	regex_subst_opts_t result = 0;
+	if (strcmp(options_str, "g") == 0) {
+                        result |= RE_SUBST_GLOBAL;
+                } else if (*options_str != '\0') {
+			memprintf(err, "invalid regex substitution options '%s'", options_str);
+			return -1;
+                }
+	return result;
+}
+
+
 /*
  * Local variables:
  *  c-indent-level: 8


### PR DESCRIPTION
This pull requests adds the http-request actions `substitute-header` and `substitute-value` and also the http-response actions `substitute-header` and `substitute-value`.

These actions are useful when needing to make substitutions multiple (and varying) number of times within a header. Also these are useful when needing to do regex substitutions with regex containing characters not allowed in regsub().

As an example consider needing to modify the contents of the Referer header 
 
From
Referer: https://a-b-c.example.com/a-b-c
To
Referer: https://a.b.c.example.com/a-b-c
 
Basically any hyphen in the subdomain part of example.com needs to be replaced by dots, but any other hyphens should not be replaced. Trying to use regsub(), the restriction on the accepted characters (no parenthesis or square brackets) limits the possible regular expressions that can be used (so regex lookaheads cannot be used). Also “http-request replace-header” is limited because it cannot do multiple substitutions – if there is more than one match, you can only reference matching groups within the first match (so varying number of matches cannot be handled). What is needed is an action similar to regsub()  but without the limitations on accepted regex. So I am suggesting the substitute-header and substitute-value actions for http requests and responses. For the example above, the following action would achieve the desired change:
`http-request susbtitute-header Referer '-(?=.*\.example\.com)'   '.'   g`
